### PR TITLE
Feat/#10 Vercel 배포 워크플로우

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -1,0 +1,49 @@
+# Workflow name
+name: 'Deploy Development'
+
+# Event for the workflow
+on:
+  push:
+    branches:
+      - develop
+
+# List of jobs
+jobs:
+  vercel-preview:
+    # Operating System
+    runs-on: ubuntu-latest
+    env:
+      WORKDIR: .
+    # Job steps
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel
+
+      - name: Pull Vercel env
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build project for Vercel
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy to Vercel
+        id: deploy
+        run: |
+          vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} > vercel-output.txt
+          echo "preview_url=$(cat vercel-output.txt)" >> $GITHUB_OUTPUT
+
+      - name: Assign Custom Domain
+        run: |
+          vercel alias set ${{ env.preview_url }} leev-dev.vercel.app --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Push Changes to Forked Repo
         run: |
           git remote add forked https://x-access-token:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/yoonncho/dnd-12th-10-frontend.git
-          git push forked HEAD:${GITHUB_REF#refs/heads/} --force
+          git push forked HEAD:${{ github.head_ref }} --force
 
       - name: Install Vercel CLI
         run: npm install -g vercel

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -38,7 +38,10 @@ jobs:
       - name: Pull Vercel env
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
-      - name: Deploy Vercel
+      - name: Build project for Vercel
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy to Vercel
         id: deploy
         run: |
           vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} > vercel-output.txt

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -34,26 +34,8 @@ jobs:
           git remote add forked https://x-access-token:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/yoonncho/dnd-12th-10-frontend.git
           git push forked HEAD:${{ github.head_ref }} --force
 
-      - name: Install Vercel CLI
-        run: npm install -g vercel
-
-      - name: Deploy to Vercel Preview
-        id: vercel_preview
-        run: |
-          DEPLOY_URL=$(vercel --token=${{ secrets.VERCEL_TOKEN }} --project-id=${{ secrets.VERCEL_PROJECT_ID }} --env preview --yes)
-          echo "Vercel Deploy URL: $DEPLOY_URL"
-          echo "DEPLOY_URL=$DEPLOY_URL" >> $GITHUB_ENV
-
-      - name: Find Pull Request
-        id: find_pr
-        uses: jwalton/gh-find-current-pr@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Comment Preview URL on PR
-        if: steps.find_pr.outputs.pr_number != ''
         uses: thollander/actions-comment-pull-request@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          pr-number: ${{ steps.find_pr.outputs.pr_number }}
           message: '🚀 Preview deployed: [${{ env.DEPLOY_URL }}](${{ env.DEPLOY_URL }})'

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,59 @@
+# Workflow name
+name: 'Deploy Preview'
+
+# Event for the workflow
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+    branches:
+      - develop
+
+# List of jobs
+jobs:
+  sync:
+    name: Sync forked repo
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Configure Git
+        run: |
+          git config user.email "nicealice99@gmail.com"
+          git config user.name "yoonncho"
+
+      - name: Push Changes to Forked Repo
+        run: |
+          git remote add forked https://x-access-token:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/YOUR_GITHUB_USERNAME/YOUR_FORKED_REPO.git
+          git push forked HEAD:${GITHUB_REF#refs/heads/} --force
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel
+
+      - name: Deploy to Vercel Preview
+        id: vercel_preview
+        run: |
+          DEPLOY_URL=$(vercel --token=${{ secrets.VERCEL_TOKEN }} --project-id=${{ secrets.VERCEL_PROJECT_ID }} --env preview --yes)
+          echo "Vercel Deploy URL: $DEPLOY_URL"
+          echo "DEPLOY_URL=$DEPLOY_URL" >> $GITHUB_ENV
+
+      - name: Find Pull Request
+        id: find_pr
+        uses: jwalton/gh-find-current-pr@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment Preview URL on PR
+        if: steps.find_pr.outputs.pr_number != ''
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ steps.find_pr.outputs.pr_number }}
+          message: '🚀 Preview deployed: [${{ env.DEPLOY_URL }}](${{ env.DEPLOY_URL }})'

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Push Changes to Forked Repo
         run: |
-          git remote add forked https://x-access-token:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/YOUR_GITHUB_USERNAME/YOUR_FORKED_REPO.git
+          git remote add forked https://x-access-token:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/yoonncho/dnd-12th-10-frontend.git
           git push forked HEAD:${GITHUB_REF#refs/heads/} --force
 
       - name: Install Vercel CLI

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -12,30 +12,42 @@ on:
 
 # List of jobs
 jobs:
-  sync:
-    name: Sync forked repo
+  vercel-preview:
+    # Operating System
     runs-on: ubuntu-latest
-
+    env:
+      WORKDIR: .
+    # Job steps
     steps:
-      - name: Checkout main
+      - name: Checkout code
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
 
-      - name: Configure Git
-        run: |
-          git config user.email "nicealice99@gmail.com"
-          git config user.name "yoonncho"
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
 
-      - name: Push Changes to Forked Repo
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel
+
+      - name: Pull Vercel env
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy Vercel
+        id: deploy
         run: |
-          git remote add forked https://x-access-token:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/yoonncho/dnd-12th-10-frontend.git
-          git push forked HEAD:${{ github.head_ref }} --force
+          vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} > vercel-output.txt
+          echo "preview_url=$(cat vercel-output.txt)" >> $GITHUB_OUTPUT
 
       - name: Comment Preview URL on PR
+        if: github.event.pull_request.number
         uses: thollander/actions-comment-pull-request@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          message: '🚀 Preview deployed: [${{ env.DEPLOY_URL }}](${{ env.DEPLOY_URL }})'
+          pr-number: ${{ github.event.pull_request.number }}
+          message: '🚀 Preview deployed: ${{ steps.deploy.outputs.preview_url }})'

--- a/src/app/_components/Banner.tsx
+++ b/src/app/_components/Banner.tsx
@@ -16,7 +16,7 @@ const Banner = () => {
       <div>
         <h3 className='text-title01 text-blue-600'>
           막막했던 회고가 특별해지는 순간 <br /> 비슷한 경험을 가진 동료들의
-          인사이트를 만나보세요.
+          인사이트를 만나보세요.11
         </h3>
         <p className='mt-2 text-blue-900 text-body01 mb-[26px]'>
           인기 회고 모임을 찾거나, 나만의 모임을 만들어볼 수 있어요!

--- a/src/app/_components/Banner.tsx
+++ b/src/app/_components/Banner.tsx
@@ -16,7 +16,7 @@ const Banner = () => {
       <div>
         <h3 className='text-title01 text-blue-600'>
           막막했던 회고가 특별해지는 순간 <br /> 비슷한 경험을 가진 동료들의
-          인사이트를 만나보세요.11
+          인사이트를 만나보세요.
         </h3>
         <p className='mt-2 text-blue-900 text-body01 mb-[26px]'>
           인기 회고 모임을 찾거나, 나만의 모임을 만들어볼 수 있어요!


### PR DESCRIPTION
## #️⃣연관된 이슈

close #10 

## 📝작업 내용

Vercel 배포를 위한 워크플로우 추가하였습니다.
PR 시에 배포된 프리뷰로 확인할 수 있도록 하였습니다.
organization 안에 있는 레포를 직접 연결하여 사용하는 경우 "유료" 플랜이 필요합니다.

무료로 사용하기 위해서는
1 ) 개인 레포로 fork 시키고, 여기서 작업한 내용이 개인 레포로 push 되어 배포되도록 하는 방법
2 ) 레포를 연결하지 않고 직접 github action으로 수동 배포

=> 1번 방법은 매번 개인 레포와 sync 맞추는 단계가 필요하고
커멘트로 프리뷰 링크를 가져오는게 쉽지않네요 258191e35a4c076b0e326ff04fb4b6159f885ea0
=> 2번 방법으로 변경했습니다. ea06fefc12721cf81e5f19ab4596ad38671b2cdd 
원래라면 vercel에서 특정 브랜치 설정만 하면 별도 작업이 필요하지 않은데 
직접 [vercel alias](https://vercel.com/docs/cli/alias#vercel-alias)로 도메인과 연결해야합니다.
dev 배포는 이 PR 머지하면서 잘 동작하는지 확인해볼게요! 490ab57be2bf3d84880e1f2122af165f8789cd72


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
