### PR TITLE
Feat/#46 회원가입 api 연결

### DIFF
--- a/src/app/login/signup/SignupContainer.tsx
+++ b/src/app/login/signup/SignupContainer.tsx
@@ -2,18 +2,21 @@
 import React from 'react'
 import { cn } from '@/utils/cn'
 import { Controller, useForm } from 'react-hook-form'
+import useSignupMutation from './_querys/useSignupMutation'
+import { UserCreateForm as UserCreateFormType } from './_types'
+
 import Button from '@/components/Button'
+import FormField from '@/components/FormField'
 import SelectBox from '@/components/SelectBox'
 import ChipButton from '@/components/ChipButton'
 import LimitedInput from '@/components/LimitedInput'
-import FormField from '@/components/FormField'
-import { KEYWORD_LIST } from '@/consts/keywordList'
 import { JOB_LIST } from './_consts/jobList'
-import { UserCreateForm as UserCreateFormType } from './_types'
+import { KEYWORD_LIST } from '@/consts/keywordList'
 
 const MAX_LENGTH = 10
 
 const SignupContainer = () => {
+  const { signupMutation, isPending } = useSignupMutation()
   const {
     control,
     register,
@@ -36,8 +39,7 @@ const SignupContainer = () => {
   }
 
   const onSubmit = async (data: UserCreateFormType) => {
-    // TODO: 추후 api 연결
-    console.log(data)
+    signupMutation(data)
   }
 
   return (
@@ -108,10 +110,10 @@ const SignupContainer = () => {
           color='primary'
           variant='filled'
           size='large'
-          disabled={!isValid}
+          disabled={!isValid || isPending}
           style={{ marginTop: 'auto' }}
         >
-          가입 완료
+          {isPending ? '요청 중..' : ' 가입 완료'}
         </Button>
       </form>
     </div>

--- a/src/app/login/signup/SignupContainer.tsx
+++ b/src/app/login/signup/SignupContainer.tsx
@@ -1,54 +1,58 @@
 'use client'
-
-import { useState } from 'react'
+import React from 'react'
 import { cn } from '@/utils/cn'
+import { Controller, useForm } from 'react-hook-form'
 import Button from '@/components/Button'
 import SelectBox from '@/components/SelectBox'
 import ChipButton from '@/components/ChipButton'
 import LimitedInput from '@/components/LimitedInput'
 import FormField from '@/components/FormField'
 import { KEYWORD_LIST } from '@/consts/keywordList'
-
 import { JOB_LIST } from './_consts/jobList'
-import { ALERT_MESSAGE } from './_consts/inputAlertMessage'
+import { UserCreateForm as UserCreateFormType } from './_types'
 
-type AlertMessageKey = keyof typeof ALERT_MESSAGE
 const MAX_LENGTH = 10
 
 const SignupContainer = () => {
-  const [alertMessage, setAlertMessage] = useState<AlertMessageKey>('NONE')
+  const {
+    control,
+    register,
+    handleSubmit,
+    formState: { isValid },
+    setValue,
+  } = useForm<UserCreateFormType>({
+    defaultValues: {
+      nickname: '',
+      job: '',
+      featureKeyword: [],
+    },
+  })
 
   const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target
-
     if (value.length > MAX_LENGTH) {
-      e.target.value = value.slice(0, MAX_LENGTH)
-      setAlertMessage('EXCEEDS_MAX_LENGTH')
-    } else {
-      setAlertMessage('NONE')
+      setValue('nickname', value.slice(0, MAX_LENGTH))
     }
   }
 
+  const onSubmit = async (data: UserCreateFormType) => {
+    // TODO: 추후 api 연결
+    console.log(data)
+  }
+
   return (
-    <div
-      className={cn(
-        'flex',
-        'flex-col',
-        'w-full h-full',
-        'mt-10',
-        'overflow-auto',
-      )}
-    >
+    <div className={cn('flex', 'flex-col', 'w-full h-full', 'overflow-auto')}>
       <div className='text-title01 mb-10'>
         <div>name님! 안녕하세요.</div>
         <div>마지막으로 추가 정보 입력을 부탁드려요!</div>
       </div>
-      <div
+      <form
+        onSubmit={handleSubmit(onSubmit)}
         className={cn(
+          'h-full',
           'flex',
           'flex-col',
           'gap-10',
-          'mb-[40px]',
           'overflow-auto',
           'pr-3',
         )}
@@ -61,16 +65,25 @@ const SignupContainer = () => {
             multiline={false}
             maxLength={MAX_LENGTH}
             placeholder='닉네임을 입력해주세요.'
-            onChange={handleInput}
-            onMaxLength={() => {}}
-            alertMessage={ALERT_MESSAGE[alertMessage]}
+            {...register('nickname', {
+              required: true,
+              maxLength: MAX_LENGTH,
+              onChange: handleInput,
+            })}
           />
         </FormField>
         <FormField fieldTitle='현재 어떤 직무이신가요?' required={true}>
-          <SelectBox
-            options={JOB_LIST}
-            placeholder='직무를 선택해주세요.'
-            onChange={() => {}}
+          <Controller
+            control={control}
+            name='job'
+            rules={{ required: true }}
+            render={({ field: { onChange } }) => (
+              <SelectBox
+                options={JOB_LIST}
+                placeholder='직무를 선택해주세요.'
+                onChange={onChange}
+              />
+            )}
           />
         </FormField>
         <FormField
@@ -78,20 +91,29 @@ const SignupContainer = () => {
           required={false}
         >
           <div className='flex flex-wrap gap-2 pb-[2px]'>
-            {KEYWORD_LIST.map((keyword) => (
-              <ChipButton label={keyword} key={keyword} />
-            ))}
+            <div className='flex flex-wrap gap-2'>
+              {KEYWORD_LIST.map((keyword, index) => (
+                <ChipButton
+                  key={`tag-${index}`}
+                  label={keyword}
+                  {...register('featureKeyword')}
+                  value={keyword}
+                />
+              ))}
+            </div>
           </div>
         </FormField>
-      </div>
-      <Button
-        color='primary'
-        variant='filled'
-        size='medium'
-        style={{ width: '100%', marginTop: 'auto' }}
-      >
-        가입 완료
-      </Button>
+        <Button
+          type='submit'
+          color='primary'
+          variant='filled'
+          size='large'
+          disabled={!isValid}
+          style={{ marginTop: 'auto' }}
+        >
+          가입 완료
+        </Button>
+      </form>
     </div>
   )
 }

--- a/src/app/login/signup/_consts/jobList.ts
+++ b/src/app/login/signup/_consts/jobList.ts
@@ -1,8 +1,8 @@
 export const JOB_LIST = [
-  { key: 'jobless', label: '취준생' },
-  { key: 'student', label: '학생' },
-  { key: 'frontend', label: '프론트엔드 개발자' },
-  { key: 'backend', label: '백엔드 개발자' },
-  { key: 'designer', label: 'UX/UI 디자이너' },
-  { key: 'content', label: '콘텐츠 디자이너' },
+  { key: '취준생', label: '취준생' },
+  { key: '학생', label: '학생' },
+  { key: '프론트엔드 개발자', label: '프론트엔드 개발자' },
+  { key: '프론트엔드 개발자', label: '백엔드 개발자' },
+  { key: 'UX/UI 디자이너', label: 'UX/UI 디자이너' },
+  { key: '콘텐츠 디자이너', label: '콘텐츠 디자이너' },
 ]

--- a/src/app/login/signup/_consts/jobList.ts
+++ b/src/app/login/signup/_consts/jobList.ts
@@ -2,7 +2,7 @@ export const JOB_LIST = [
   { key: '취준생', label: '취준생' },
   { key: '학생', label: '학생' },
   { key: '프론트엔드 개발자', label: '프론트엔드 개발자' },
-  { key: '프론트엔드 개발자', label: '백엔드 개발자' },
+  { key: '백엔드 개발자', label: '백엔드 개발자' },
   { key: 'UX/UI 디자이너', label: 'UX/UI 디자이너' },
   { key: '콘텐츠 디자이너', label: '콘텐츠 디자이너' },
 ]

--- a/src/app/login/signup/_lib/index.ts
+++ b/src/app/login/signup/_lib/index.ts
@@ -1,0 +1,13 @@
+import { axiosInstance } from '@/lib/axios'
+import { API_PATH } from '@/consts/urls'
+import { UserCreateForm as UserCreateFormType } from '@/app/login/signup/_types'
+
+export const signup = async (data: UserCreateFormType) => {
+  try {
+    const response = await axiosInstance.patch(API_PATH.Signup, data)
+    return response.status === 200
+  } catch (error) {
+    console.error('Error during token reissue:', error)
+    throw error
+  }
+}

--- a/src/app/login/signup/_lib/index.ts
+++ b/src/app/login/signup/_lib/index.ts
@@ -3,11 +3,5 @@ import { API_PATH } from '@/consts/urls'
 import { UserCreateForm as UserCreateFormType } from '@/app/login/signup/_types'
 
 export const signup = async (data: UserCreateFormType) => {
-  try {
-    const response = await axiosInstance.patch(API_PATH.Signup, data)
-    return response.status === 200
-  } catch (error) {
-    console.error('Error during token reissue:', error)
-    throw error
-  }
+  return await axiosInstance.patch(API_PATH.Signup, data)
 }

--- a/src/app/login/signup/_querys/useSignupMutation.ts
+++ b/src/app/login/signup/_querys/useSignupMutation.ts
@@ -3,6 +3,11 @@ import { useMutation } from '@tanstack/react-query'
 import { URL_PATH } from '@/consts/urls'
 import openCustomToast from '@/utils/openCustomToast'
 import { signup } from '../_lib'
+import { AxiosError } from 'axios'
+
+interface ErrorResponse {
+  code: string
+}
 
 const useSignupMutation = () => {
   const { replace } = useRouter()
@@ -13,7 +18,13 @@ const useSignupMutation = () => {
       openCustomToast('회원가입 성공', true, '✅')
       replace(URL_PATH.Home)
     },
-    onError: () => openCustomToast('회원가입 실패', true, '❌'),
+    onError: (error: AxiosError<ErrorResponse>) => {
+      if (error.response?.data?.code === '409') {
+        return openCustomToast('닉네임이 중복되었습니다.', true, '❌')
+      }
+
+      openCustomToast('회원가입 실패', true, '❌')
+    },
   })
 
   return { signupMutation, isPending }

--- a/src/app/login/signup/_querys/useSignupMutation.ts
+++ b/src/app/login/signup/_querys/useSignupMutation.ts
@@ -1,0 +1,22 @@
+import { useRouter } from 'next/navigation'
+import { useMutation } from '@tanstack/react-query'
+import { URL_PATH } from '@/consts/urls'
+import OpenCustomToast from '@/utils/openCustomToast'
+import { signup } from '../_lib'
+
+const useSignupMutation = () => {
+  const { replace } = useRouter()
+
+  const { mutate: signupMutation, isPending } = useMutation({
+    mutationFn: signup,
+    onSuccess: () => {
+      OpenCustomToast('회원가입 성공', true, '✅')
+      replace(URL_PATH.Home)
+    },
+    onError: () => OpenCustomToast('회원가입 실패', true, '❌'),
+  })
+
+  return { signupMutation, isPending }
+}
+
+export default useSignupMutation

--- a/src/app/login/signup/_querys/useSignupMutation.ts
+++ b/src/app/login/signup/_querys/useSignupMutation.ts
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/navigation'
 import { useMutation } from '@tanstack/react-query'
 import { URL_PATH } from '@/consts/urls'
-import OpenCustomToast from '@/utils/openCustomToast'
+import openCustomToast from '@/utils/openCustomToast'
 import { signup } from '../_lib'
 
 const useSignupMutation = () => {
@@ -10,10 +10,10 @@ const useSignupMutation = () => {
   const { mutate: signupMutation, isPending } = useMutation({
     mutationFn: signup,
     onSuccess: () => {
-      OpenCustomToast('회원가입 성공', true, '✅')
+      openCustomToast('회원가입 성공', true, '✅')
       replace(URL_PATH.Home)
     },
-    onError: () => OpenCustomToast('회원가입 실패', true, '❌'),
+    onError: () => openCustomToast('회원가입 실패', true, '❌'),
   })
 
   return { signupMutation, isPending }

--- a/src/app/login/signup/_types/index.ts
+++ b/src/app/login/signup/_types/index.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod'
+
+export const userCreateSchema = z.object({
+  nickname: z.string(),
+  job: z.string(),
+  featureKeyword: z.array(z.string()),
+})
+
+export type UserCreateForm = z.infer<typeof userCreateSchema>

--- a/src/app/login/success/LoginSuccess.tsx
+++ b/src/app/login/success/LoginSuccess.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import { useEffect } from 'react'
-import { toast } from 'react-hot-toast'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { URL_PATH } from '@/consts/urls'
 import { useAuthStore } from '@/store/auth'
 import { setAccessToken } from '@/lib/axios'
+import OpenCustomToast from '@/utils/openCustomToast'
 
 const SuccessPage = () => {
   const { setIsLogin } = useAuthStore()
@@ -22,17 +22,17 @@ const SuccessPage = () => {
         setIsLogin(true)
         router.replace(isRegistered ? URL_PATH.Signup : URL_PATH.Home)
       } else {
-        toast.error('로그인에 실패했습니다')
+        OpenCustomToast('로그인에 실패했습니다', true, '❌')
         router.replace(URL_PATH.Login)
       }
     } catch (err) {
       console.error(err)
-      toast.error('로그인에 실패했습니다')
+      OpenCustomToast('로그인에 실패했습니다', true, '❌')
       router.replace(URL_PATH.Login)
     }
   }, [searchParams, setAccessToken])
 
-  return <div>Success</div>
+  return null
 }
 
 export default SuccessPage

--- a/src/app/login/success/LoginSuccess.tsx
+++ b/src/app/login/success/LoginSuccess.tsx
@@ -15,12 +15,12 @@ const SuccessPage = () => {
   useEffect(() => {
     try {
       const accessToken = searchParams.get('access_token')
-      const isRegistered = searchParams.get('isRegistered')
+      const isRegistered = searchParams.get('isRegistered') !== 'false'
 
-      if (accessToken && isRegistered) {
+      if (accessToken) {
         setAccessToken(accessToken)
         setIsLogin(true)
-        router.replace(isRegistered ? URL_PATH.Home : URL_PATH.Signup)
+        router.replace(isRegistered ? URL_PATH.Signup : URL_PATH.Home)
       } else {
         toast.error('로그인에 실패했습니다')
         router.replace(URL_PATH.Login)

--- a/src/components/SelectBox/index.tsx
+++ b/src/components/SelectBox/index.tsx
@@ -48,7 +48,7 @@ const SelectBox = ({ options, placeholder, onChange }: Props) => {
       selectorIcon={<Icon name='arrow-down' className='stroke-gray-700' />}
       onChange={onChange}
     >
-      {({ label }) => <SelectItem>{label}</SelectItem>}
+      {({ key, label }) => <SelectItem key={key + label}>{label}</SelectItem>}
     </Select>
   )
 }

--- a/src/components/SelectBox/index.tsx
+++ b/src/components/SelectBox/index.tsx
@@ -48,7 +48,7 @@ const SelectBox = ({ options, placeholder, onChange }: Props) => {
       selectorIcon={<Icon name='arrow-down' className='stroke-gray-700' />}
       onChange={onChange}
     >
-      {({ key, label }) => <SelectItem key={key + label}>{label}</SelectItem>}
+      {({ key, label }) => <SelectItem key={key}>{label}</SelectItem>}
     </Select>
   )
 }

--- a/src/consts/urls.ts
+++ b/src/consts/urls.ts
@@ -10,7 +10,7 @@ export const URL_PATH = {
 }
 
 export const API_PATH = {
-  Login: '/api/v1/auth/oauth2/kakao',
-  ReissueToken: '/api/v1/auth/reissue',
-  Signup: '/api/v1/user/after-login',
+  Login: '/auth/oauth2/kakao',
+  ReissueToken: '/auth/reissue',
+  Signup: '/user/after-login',
 }

--- a/src/consts/urls.ts
+++ b/src/consts/urls.ts
@@ -12,4 +12,5 @@ export const URL_PATH = {
 export const API_PATH = {
   Login: '/api/v1/auth/oauth2/kakao',
   ReissueToken: '/api/v1/auth/reissue',
+  Signup: '/api/v1/user/after-login',
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,9 +3,7 @@ import { API_PATH } from '@/consts/urls'
 
 export const reissueToken = async () => {
   try {
-    const response = await axiosInstance.get(API_PATH.ReissueToken, {
-      withCredentials: true,
-    })
+    const response = await axiosInstance.get(API_PATH.ReissueToken)
 
     if (response.status === 200) {
       let newAccessToken = response.headers['authorization']

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -21,6 +21,7 @@ export const axiosInstance = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
+  withCredentials: true,
 })
 
 // 요청 인터셉터: 토큰이 있다면 헤더에 추가

--- a/src/utils/openCustomToast.ts
+++ b/src/utils/openCustomToast.ts
@@ -1,10 +1,15 @@
 import { Toast, toast } from 'react-hot-toast'
 import CustomToast from '@/components/CustomToast'
 
-const openCustomToast = (message: string, isShowCloseButton: boolean) => {
+const openCustomToast = (
+  message: string,
+  isShowCloseButton: boolean,
+  icon?: string,
+) => {
   toast(
     (t: Toast) => CustomToast({ message, isShowCloseButton, toastId: t.id }),
     {
+      icon: icon,
       style: {
         borderRadius: '4px',
         padding: '12px 16px',


### PR DESCRIPTION
## #️⃣연관된 이슈

#46 

## 📝작업 내용

-  SelectItem Key prop 추가 5f59d511c7bc236d3680d2b930cac5db8037242c
- JOB_LIST key 값 label 동일하게 변경 022cb3d2e2b74dbaa80fe7225f26a7b18707314d
  : SelectItem의 onChange의 발생 시 value가 key를 사용함에 따라 key값 변경
- isRegistered에 따른 주소 이동 값 반대로 변경 cfe425b2758b635f08924d13ab72c71bc3d5f7f7
- signup페이지 react-hook-form 적용 2b0c8fae54e345165fa851e06a19cdd6cf8db788
- OpenCustomToast icon 옵션 추가 eaf1d3187f4c55cdefb6c94306d90483f66bbba6
- useMutation을 활용해 회원가입 api 연결 9ef3fc5399aac7046dac7b85f7c4746e0db1343e

### 스크린샷 (선택)
https://github.com/user-attachments/assets/74d9d555-5819-4572-92e8-d6997e3d1379


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
