### PR TITLE
Feat/#62 내 정보 페이지 퍼블리싱 및 api 연결

### DIFF
--- a/src/app/login/signup/SignupContainer.tsx
+++ b/src/app/login/signup/SignupContainer.tsx
@@ -30,7 +30,7 @@ const SignupContainer = () => {
     defaultValues: {
       nickname: '',
       job: '',
-      featureKeyword: [],
+      featureKeywordList: [],
     },
   })
 
@@ -101,7 +101,7 @@ const SignupContainer = () => {
                 <ChipButton
                   key={`tag-${index}`}
                   label={keyword}
-                  {...register('featureKeyword')}
+                  {...register('featureKeywordList')}
                   value={keyword}
                 />
               ))}

--- a/src/app/login/signup/SignupContainer.tsx
+++ b/src/app/login/signup/SignupContainer.tsx
@@ -12,10 +12,13 @@ import ChipButton from '@/components/ChipButton'
 import LimitedInput from '@/components/LimitedInput'
 import { JOB_LIST } from './_consts/jobList'
 import { KEYWORD_LIST } from '@/consts/keywordList'
+import useUserDataQuery from '@/querys/useUserDataQuery'
 
 const MAX_LENGTH = 10
 
 const SignupContainer = () => {
+  const { userData } = useUserDataQuery()
+
   const { signupMutation, isPending } = useSignupMutation()
   const {
     control,
@@ -45,7 +48,7 @@ const SignupContainer = () => {
   return (
     <div className={cn('flex', 'flex-col', 'w-full h-full', 'overflow-auto')}>
       <div className='text-title01 mb-10'>
-        <div>name님! 안녕하세요.</div>
+        <div>{userData?.nickname}님! 안녕하세요.</div>
         <div>마지막으로 추가 정보 입력을 부탁드려요!</div>
       </div>
       <form

--- a/src/app/login/signup/_querys/useSignupMutation.ts
+++ b/src/app/login/signup/_querys/useSignupMutation.ts
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/navigation'
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { URL_PATH } from '@/consts/urls'
 import openCustomToast from '@/utils/openCustomToast'
 import { signup } from '../_lib'
@@ -11,11 +11,13 @@ interface ErrorResponse {
 
 const useSignupMutation = () => {
   const { replace } = useRouter()
+  const queryClient = useQueryClient()
 
   const { mutate: signupMutation, isPending } = useMutation({
     mutationFn: signup,
     onSuccess: () => {
       openCustomToast('회원가입 성공', true, '✅')
+      queryClient.invalidateQueries({ queryKey: ['UserData'] })
       replace(URL_PATH.Home)
     },
     onError: (error: AxiosError<ErrorResponse>) => {

--- a/src/app/login/signup/_types/index.ts
+++ b/src/app/login/signup/_types/index.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 export const userCreateSchema = z.object({
   nickname: z.string(),
   job: z.string(),
+  //Todo: user조회 데이터랑 동기화 필요
   featureKeyword: z.array(z.string()),
 })
 

--- a/src/app/login/signup/_types/index.ts
+++ b/src/app/login/signup/_types/index.ts
@@ -3,8 +3,7 @@ import { z } from 'zod'
 export const userCreateSchema = z.object({
   nickname: z.string(),
   job: z.string(),
-  //Todo: user조회 데이터랑 동기화 필요
-  featureKeyword: z.array(z.string()),
+  featureKeywordList: z.array(z.string()),
 })
 
 export type UserCreateForm = z.infer<typeof userCreateSchema>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import useUserDataQuery from '@/querys/useUserDataQuery'
+import MyMemoStatus from '@/app/memos/_components/MyMemoStatus'
+import ChipButton from '@/components/ChipButton'
+
+const ProfilePage = () => {
+  const { userData } = useUserDataQuery()
+
+  if (!userData) return null
+
+  return (
+    <div className='px-[88px] py-[70px]'>
+      <div className='p-10 mb-20 bg-gray-50 rounded-md'>
+        <p className='text-title01'>{userData.nickname}님 안녕하세요!</p>
+        <p className='mt-4 text-body03 text-gray-500'>관심있는 키워드</p>
+        <div className='mt-2 flex text-body03 gap-2'>
+          {userData.featureKeywordList.map((keyword, index) => (
+            <ChipButton
+              key={`${keyword}-${index}`}
+              label={keyword}
+              disabled={true}
+            />
+          ))}
+        </div>
+      </div>
+      <MyMemoStatus />
+    </div>
+  )
+}
+
+export default ProfilePage

--- a/src/components/ChipButton/index.tsx
+++ b/src/components/ChipButton/index.tsx
@@ -19,6 +19,7 @@ const ChipButton = ({ label, ...restProps }: Props) => {
           'justify-center',
           'text-gray-800',
           'text-body03',
+          'text-nowrap',
           'px-3',
           'cursor-pointer',
           'rounded-sm',
@@ -27,6 +28,7 @@ const ChipButton = ({ label, ...restProps }: Props) => {
           'select-none',
           'border border-gray-900',
           'shadow-[0px_2px_0px_0px_#000000]',
+          'bg-white',
           'peer-checked:bg-green-500',
           'peer-checked:text-white',
         )}

--- a/src/components/RootLayout/NavigateList/index.tsx
+++ b/src/components/RootLayout/NavigateList/index.tsx
@@ -19,7 +19,11 @@ const NavigateList = () => {
         iconName='profile-user'
       />
       {/*<NotificationLink />*/}
-      <SidebarItem path='/4' contentName='내 정보' iconName='profile' />
+      <SidebarItem
+        path={URL_PATH.Profile}
+        contentName='내 정보'
+        iconName='profile'
+      />
     </nav>
   )
 }

--- a/src/consts/urls.ts
+++ b/src/consts/urls.ts
@@ -3,6 +3,7 @@ export const URL_PATH = {
   Memos: '/memos',
   Group: '/group',
   GroupList: '/groups',
+  Profile: '/profile',
   GroupCreate: '/groups/create',
   Login: '/login',
   LoginSuccess: '/login/success',

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -5,6 +5,7 @@ export interface getUserDataResponse {
   userId: string
   nickname: string
   profileUrl: string
+  featureKeywordList: string[]
 }
 
 export const getUserData = async (): Promise<getUserDataResponse> => {


### PR DESCRIPTION
## #️⃣연관된 이슈

#62 

## 📝작업 내용

- signup username api로 받아오기 5a102b9b5157029d9215a1639d1fbbec1c486b97
  : 처음 화면에 표시되는 유저이름을 나타내는 api 요청 및 회원가입 요청 후 UserData 캐싱 업데이트 로직 추가 
- 내 정보 페이지 퍼블리싱 및 api 연결 44541931a5550d2273741b9eea73108b80b467bb
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
