### PR TITLE
Refactor/#80 모임 탈퇴 기능 추가 및 모달창 ui 수정

### DIFF
--- a/src/app/groups/[id]/GroupDetail.tsx
+++ b/src/app/groups/[id]/GroupDetail.tsx
@@ -1,5 +1,5 @@
 'use client'
-
+import { useState } from 'react'
 import { cn } from '@/utils/cn'
 import GroupHeading from './_components/GroupHeading'
 import GroupDescription from './_components/GroupDescription'
@@ -11,10 +11,11 @@ import Spinner from '@/components/Spinner'
 import useGetGroupInfo from './_queries/useGetGroupInfo'
 import useGetRetrospectList from './_queries/useGetRetrospectList'
 import { ROLE } from './_consts'
-import GroupActionsDropdown from '@/app/groups/[id]/_components/GroupActionsDropdown'
+import GroupActionsDropdown from './_components/GroupActionsDropdown'
 import Confirm from '@/components/Confirm'
-import useDeleteGroupMutation from '@/app/groups/[id]/_queries/useDeleteGroupMutation'
-import { useState } from 'react'
+import useDeleteGroupMutation from './_queries/useDeleteGroupMutation'
+import useLeaveGroupMutation from './_queries/useLeaveGroupMutation'
+import { ConfirmModal } from './_types'
 
 const GroupDetail = () => {
   const groupId = useParams<{ id: string }>()?.id
@@ -22,8 +23,26 @@ const GroupDetail = () => {
   const { data: groupInfo } = useGetGroupInfo(groupId)
   const { data: retrospectList } = useGetRetrospectList(groupId)
   const { mutate: deleteGroup } = useDeleteGroupMutation(String(groupId))
+  const { mutate: leaveGroup } = useLeaveGroupMutation(String(groupId))
 
   if (!groupInfo) return <Spinner />
+
+  const confirmModalContent: ConfirmModal =
+    groupInfo.role === 'LEADER'
+      ? {
+          title: '선택한 모임을 삭제하시겠습니까?',
+          message: '삭제된 모임은 복구되지 않습니다.',
+          onConfirmText: '삭제하기',
+          onConfirm: deleteGroup,
+        }
+      : {
+          title: '선택한 모임을 탈퇴하시겠습니까?',
+          message: '탈퇴한 모임은 다시 참여할 수 없습니다.',
+          onConfirmText: '탈퇴하기',
+          onConfirm: leaveGroup,
+        }
+
+  const { title, message, onConfirm, onConfirmText } = confirmModalContent
 
   const {
     groupName,
@@ -63,13 +82,15 @@ const GroupDetail = () => {
             createdAtGroup={createDate}
             latestUpdateTime={recentActString}
           />
-          <GroupActionsDropdown
-            role={role}
-            groupId={Number(groupId)}
-            openDeleteGroupConfirm={() => {
-              setIsModalOpen(true)
-            }}
-          />
+          {role !== 'NON_MEMBER' && (
+            <GroupActionsDropdown
+              role={role}
+              groupId={Number(groupId)}
+              openModal={() => {
+                setIsModalOpen(true)
+              }}
+            />
+          )}
         </div>
         {description && <GroupDescription description={description} />}
       </div>
@@ -90,14 +111,13 @@ const GroupDetail = () => {
       <Confirm
         isDanger={true}
         isOpen={isModalOpen}
-        title='선택한 모임을 삭제하시겠습니까?'
-        message='삭제된 모임은 복구되지 않습니다.'
+        title={title}
+        message={message}
         onCancel={() => {
           setIsModalOpen(false)
         }}
-        onConfirm={() => {
-          deleteGroup()
-        }}
+        onConfirm={onConfirm}
+        onConfirmText={onConfirmText}
       />
     </div>
   )

--- a/src/app/groups/[id]/GroupDetail.tsx
+++ b/src/app/groups/[id]/GroupDetail.tsx
@@ -88,6 +88,7 @@ const GroupDetail = () => {
         />
       )}
       <Confirm
+        isDanger={true}
         isOpen={isModalOpen}
         title='선택한 모임을 삭제하시겠습니까?'
         message='삭제된 모임은 복구되지 않습니다.'

--- a/src/app/groups/[id]/_components/GroupActionsDropdown.tsx
+++ b/src/app/groups/[id]/_components/GroupActionsDropdown.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenu,
   DropdownTrigger,
 } from '@heroui/dropdown'
+import copyToCurrentUrl from '../_utils/copyToCurrentUrl'
 
 /** 모임 액션 메뉴(수정, 삭제) 드롭다운 */
 const GroupActionsDropdown = ({
@@ -63,6 +64,7 @@ const getMenuItems = ({ isLeader, groupId, openModal }: MenuItemProps) => {
       {ActionItem({
         key: 'copy',
         label: '링크 복사하기',
+        onPress: copyToCurrentUrl,
       })}
       {ActionItem({
         key: 'leave',

--- a/src/app/groups/[id]/_components/GroupActionsDropdown.tsx
+++ b/src/app/groups/[id]/_components/GroupActionsDropdown.tsx
@@ -1,19 +1,23 @@
 import Link from 'next/link'
-import { Group } from '../_types'
+import { ActionItemProps, Group, MenuItemProps } from '../_types'
 import { Icon } from '@/components/Icon'
 import { URL_PATH } from '@/consts/urls'
-import { Dropdown as DropdownHero } from '@heroui/dropdown'
-import { DropdownItem, DropdownMenu, DropdownTrigger } from '@heroui/react'
+import {
+  Dropdown as DropdownHero,
+  DropdownItem,
+  DropdownMenu,
+  DropdownTrigger,
+} from '@heroui/dropdown'
 
 /** 모임 액션 메뉴(수정, 삭제) 드롭다운 */
 const GroupActionsDropdown = ({
   role,
   groupId,
-  openDeleteGroupConfirm,
+  openModal,
 }: {
   role: Group['role']
   groupId: number
-  openDeleteGroupConfirm: VoidFunction
+  openModal: VoidFunction
 }) => {
   const isLeader = role === 'LEADER'
 
@@ -24,52 +28,69 @@ const GroupActionsDropdown = ({
           <Icon name='more' className='fill-gray-400' size={20} />
         </button>
       </DropdownTrigger>
-      {isLeader ? (
-        <LeaderMenu
-          openDeleteGroupConfirm={openDeleteGroupConfirm}
-          groupId={groupId}
-        />
-      ) : (
-        <MemberMenu />
-      )}
+      <DropdownMenu aria-label='Group Actions Menu'>
+        {getMenuItems({ isLeader, groupId, openModal })}
+      </DropdownMenu>
     </DropdownHero>
   )
 }
 
 export default GroupActionsDropdown
 
-const LeaderMenu = ({
-  groupId,
-  openDeleteGroupConfirm,
-}: {
-  groupId: number
-  openDeleteGroupConfirm: VoidFunction
-}) => {
+/** 액션 메뉴 항목 생성 함수 */
+const getMenuItems = ({ isLeader, groupId, openModal }: MenuItemProps) => {
+  if (isLeader) {
+    return (
+      <>
+        {ActionItem({
+          key: 'update',
+          label: '수정하기',
+          as: Link,
+          href: `${URL_PATH.GroupUpdate}/${groupId}`,
+        })}
+        {ActionItem({
+          key: 'delete',
+          label: '모임 삭제하기',
+          onPress: openModal,
+          color: 'danger',
+        })}
+      </>
+    )
+  }
+
   return (
     <>
-      <DropdownMenu aria-label='Leader Actions Menu'>
-        <DropdownItem
-          key='update'
-          as={Link}
-          href={URL_PATH.GroupUpdate + `/${groupId}`}
-        >
-          수정하기
-        </DropdownItem>
-        <DropdownItem key='delete' color='danger'>
-          <button onClick={openDeleteGroupConfirm}>모임 삭제하기</button>
-        </DropdownItem>
-      </DropdownMenu>
+      {ActionItem({
+        key: 'copy',
+        label: '링크 복사하기',
+      })}
+      {ActionItem({
+        key: 'leave',
+        label: '탈퇴하기',
+        onPress: openModal,
+        color: 'danger',
+      })}
     </>
   )
 }
 
-const MemberMenu = () => {
-  return (
-    <DropdownMenu aria-label='Member Actions Menu'>
-      <DropdownItem key='copy'>링크 복사하기</DropdownItem>
-      <DropdownItem key='leave' color='danger'>
-        탈퇴하기
-      </DropdownItem>
-    </DropdownMenu>
-  )
-}
+/** 개별 액션 항목 컴포넌트 */
+const ActionItem = ({
+  key,
+  label,
+  onPress,
+  color,
+  as = 'button',
+  href,
+}: ActionItemProps) => (
+  <DropdownItem
+    key={key}
+    color={color}
+    as={as}
+    href={href}
+    onPress={onPress}
+    className='text-center'
+  >
+    {label}
+  </DropdownItem>
+)

--- a/src/app/groups/[id]/_lib/index.ts
+++ b/src/app/groups/[id]/_lib/index.ts
@@ -58,3 +58,10 @@ export const deleteGroup = async (groupId: string) => {
   const response = await axiosInstance.delete(`${API_PATH.Group}/${groupId}`)
   return response.data
 }
+
+export const leaveGroup = async (groupId: string) => {
+  const response = await axiosInstance.delete(`${API_PATH.GroupLeave}`, {
+    data: { groupId },
+  })
+  return response.data
+}

--- a/src/app/groups/[id]/_queries/useLeaveGroupMutation.ts
+++ b/src/app/groups/[id]/_queries/useLeaveGroupMutation.ts
@@ -1,0 +1,25 @@
+import { useMutation } from '@tanstack/react-query'
+import { leaveGroup } from '@/app/groups/[id]/_lib'
+import { useRouter } from 'next/navigation'
+import { URL_PATH } from '@/consts/urls'
+import OpenCustomToast from '@/utils/openCustomToast'
+import useInvalidateQueries from '@/hooks/useInvalidateQueries'
+
+const useLeaveGroupMutation = (groupId: string) => {
+  const invalidateQueries = useInvalidateQueries()
+  const { replace } = useRouter()
+
+  return useMutation({
+    mutationFn: async () => await leaveGroup(groupId),
+    onSuccess: () => {
+      OpenCustomToast('모임에 탈퇴했습니다', true, '✅')
+      invalidateQueries(['MyGroup'])
+      invalidateQueries(['getGroupInfo', groupId])
+      replace(URL_PATH.GroupList)
+    },
+    // 공통 에러 처리 필요
+    onError: (error) => console.error(error),
+  })
+}
+
+export default useLeaveGroupMutation

--- a/src/app/groups/[id]/_types/index.ts
+++ b/src/app/groups/[id]/_types/index.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 import { ROLE } from '../_consts'
+import { UseMutateFunction } from '@tanstack/react-query'
+import Link from 'next/link'
 
 export const groupSchema = z.object({
   groupId: z.number(),
@@ -70,3 +72,25 @@ export type CommentList = z.infer<typeof commentListSchema>
 export type ReplyList = z.infer<typeof replyListSchema>
 export type GroupJoin = z.infer<typeof groupJoinSchema>
 export type GroupJoinResponse = z.infer<typeof gropJoinReponseSchema>
+
+export interface ConfirmModal {
+  title: string
+  message: string
+  onConfirmText: string
+  onConfirm: UseMutateFunction
+}
+
+export interface MenuItemProps {
+  isLeader: boolean
+  groupId: number
+  openModal: VoidFunction
+}
+
+export interface ActionItemProps {
+  key: string
+  label: string
+  onPress?: VoidFunction
+  color?: 'danger'
+  as?: 'button' | typeof Link
+  href?: string
+}

--- a/src/app/groups/[id]/_utils/copyToClipboard.ts
+++ b/src/app/groups/[id]/_utils/copyToClipboard.ts
@@ -1,0 +1,10 @@
+const copyToClipboard = async (text: string) => {
+  try {
+    await navigator.clipboard.writeText(text)
+    alert('클립보드에 복사되었습니다.')
+  } catch (err) {
+    console.error('클립보드 복사 실패:', err)
+  }
+}
+
+export default copyToClipboard

--- a/src/app/groups/[id]/_utils/copyToCurrentUrl.ts
+++ b/src/app/groups/[id]/_utils/copyToCurrentUrl.ts
@@ -1,0 +1,8 @@
+import copyToClipboard from '@/app/groups/[id]/_utils/copyToClipboard'
+
+const copyToCurrentUrl = () => {
+  const currentUrl = window.document.location.href
+  copyToClipboard(currentUrl)
+}
+
+export default copyToCurrentUrl

--- a/src/components/Button/consts.ts
+++ b/src/components/Button/consts.ts
@@ -50,9 +50,25 @@ export const BUTTON_STYLE: {
     text: '',
   },
   mono: {
-    subtle: ['bg-gray-100', 'text-white', 'hover:bg-gray-900'].join(' '),
-    filled: '',
-    outlined: '', // mono 색상은 현재 해당 variant 존재하지 않음
+    filled: [
+      'bg-gray-100',
+      'text-gray-900',
+      'hover:bg-gray-900',
+      'hover:text-white',
+    ].join(' '),
+    subtle: [
+      'bg-gray-50',
+      'text-gray-900',
+      'disabled:text-gray-400',
+      'hover:bg-gray-300',
+    ].join(' '),
+    outlined: [
+      'bg-white',
+      'border border-[2px] border-gray-600',
+      'text-gray-600',
+      'hover:bg-gray-50',
+      'disabled:bg-gray-50 disabled:text-gray-400 disabled:border-gray-300',
+    ].join(' '),
     text: '',
   },
 }

--- a/src/components/Confirm/index.tsx
+++ b/src/components/Confirm/index.tsx
@@ -9,6 +9,7 @@ interface ConfirmProps {
   message: string
   onConfirm: VoidFunction
   onCancel: VoidFunction
+  onConfirmText?: string
 }
 
 const Confirm = ({
@@ -18,10 +19,11 @@ const Confirm = ({
   message,
   onConfirm,
   onCancel,
+  onConfirmText = '확인',
 }: ConfirmProps) => {
   return (
     <Portal isOpen={isOpen}>
-      <div className='fixed flex inset-0 pt-4 justify-center '>
+      <div className='fixed flex inset-0 pt-4 justify-center'>
         <div
           className={cn(
             'h-fit',
@@ -54,7 +56,7 @@ const Confirm = ({
               size='small'
               onClick={onConfirm}
             >
-              확인
+              {onConfirmText}
             </Button>
           </div>
         </div>

--- a/src/components/Confirm/index.tsx
+++ b/src/components/Confirm/index.tsx
@@ -3,6 +3,7 @@ import Button from '@/components/Button'
 import { cn } from '@/utils/cn'
 
 interface ConfirmProps {
+  isDanger?: boolean
   isOpen: boolean
   title: string
   message: string
@@ -11,6 +12,7 @@ interface ConfirmProps {
 }
 
 const Confirm = ({
+  isDanger = false,
   isOpen,
   title,
   message,
@@ -36,7 +38,7 @@ const Confirm = ({
               style={{
                 minWidth: '72px',
               }}
-              color='primary'
+              color={isDanger ? 'mono' : 'primary'}
               variant='subtle'
               size='small'
               onClick={onCancel}
@@ -47,7 +49,7 @@ const Confirm = ({
               style={{
                 minWidth: '72px',
               }}
-              color='primary'
+              color={isDanger ? 'secondary' : 'primary'}
               variant='filled'
               size='small'
               onClick={onConfirm}

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -27,7 +27,7 @@ const Modal = ({ isOpen, onClose, children, left = 0 }: ModalProps) => {
         animate='animate'
         exit='exit'
         onClick={handleBackdropClick}
-        className='fixed inset-0 flex items-center justify-center bg-gray-800 bg-opacity-50'
+        className='fixed inset-0 flex items-center justify-center bg-gray-800 bg-opacity-50 z-20'
         style={{ left }}
       >
         <div className='bg-white p-10 rounded-md shadow-modal'>{children}</div>

--- a/src/consts/urls.ts
+++ b/src/consts/urls.ts
@@ -36,6 +36,7 @@ export const API_PATH = {
   RetrospectList: '/retrospect/all',
   Comment: '/comment',
   GroupJoin: '/group/join',
+  GroupLeave: '/group/leave',
   GetMyMemoList: '/memo',
   GetMemo: `/memo`,
   MemoCreate: '/memo',


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #80 
- close #86 

## 📝작업 내용
- 모노 색상 variants 업데이트 efac99bdc309029f6d3c7d081fd8fc3b3addc0d1
- 기존 confirm컴포넌트에서 용도(isDanger)에 따른 버튼 색상 추가 및 text를 props으로 전달 할 수 있도록 수정 f21936e17b19b62ba95721714b55dd94692e05ce
- heroUI의 `DropDown`컴포넌트의 명시된 z-index 때문에 모달보다 상단에 위치되어 모달 컴포넌트에 z-index 추가 c766bd77b3a34644764a462af90daad816650cf1
- 그룹 탈퇴기능 api 추가 및 query 구현 62aab9ae53b0462ce50b8ef8ad6680140d7b7c22
- 모달 content를 role에 따라 그룹 탈퇴 또는 그룹 삭제 메뉴 분기 처리 616dac67bf26177f8ff132fbe7993a8cd63a294a
- 클립보드에 현재 url 복사 기능 추가 (Member일 경우 modal의 액션 기능 중 하나) dceda7b96951eed6e6fa858f40ea631a2b6f375d

### 스크린샷 (선택)

**Leader일 경우 그룹 삭제 모달**
<img width="500" alt="스크린샷 2025-07-04 오후 2 09 54" src="https://github.com/user-attachments/assets/4b51e402-d8fd-4ac8-a5ce-7c33a47d97be" />

**Meber일 경우 그룹 탈퇴 모달**
<img width="500" alt="스크린샷 2025-07-04 오후 2 10 07" src="https://github.com/user-attachments/assets/7b570774-bd5c-4872-adc2-da37ed700359" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
