### PR TITLE
Refactor/#89 홈 화면 인기 모임 UI 수정

### DIFF
--- a/src/app/_components/PopularGroupList.tsx
+++ b/src/app/_components/PopularGroupList.tsx
@@ -1,20 +1,19 @@
 'use client'
 
 import { useState } from 'react'
-import Link from 'next/link'
 import { cn } from '@/utils/cn'
 import Chip from '@/components/Chip'
 import { Icon } from '@/components/Icon'
 import { Group } from '../_types'
 import SectionHeader from './SectionHeader'
 import usePopularGroupListQuery from '../_queries/usePopularGroupListQuery'
-import { URL_PATH } from '@/consts/urls'
 import PopularRetrospectCard from './PopularRetrospectCard'
 
 /** 인기 모임 영역 */
 const PopularGroupList = () => {
   const [currentActiveRetrospect, setCurrentActiveRetrospect] = useState(0)
   const { popularGroupList = [] } = usePopularGroupListQuery()
+  const currentGroup = popularGroupList[currentActiveRetrospect]
 
   return (
     <section className='py-6 bg-[#FAF8F5] -mx-[88px] px-[88px]'>
@@ -25,7 +24,7 @@ const PopularGroupList = () => {
             <PopularGroupCard
               rank={index + 1}
               isActive={currentActiveRetrospect === index}
-              onMouseEnter={() => {
+              onClick={() => {
                 setCurrentActiveRetrospect(index)
               }}
               key={`popular-group-${props.groupResponseDto.groupId}`}
@@ -34,7 +33,8 @@ const PopularGroupList = () => {
           ))}
         </div>
         <PopularRetrospectCard
-          {...popularGroupList[currentActiveRetrospect]?.retrospectResponseDto}
+          {...currentGroup?.retrospectResponseDto}
+          groupId={currentGroup?.groupResponseDto.groupId}
         />
       </div>
     </section>
@@ -46,26 +46,24 @@ export default PopularGroupList
 const PopularGroupCard = ({
   rank,
   isActive,
-  onMouseEnter,
-  groupId,
+  onClick,
   groupName,
   userCount,
   categoryNames,
-}: Group & { rank: number; isActive: boolean; onMouseEnter: () => void }) => {
+}: Group & { rank: number; isActive: boolean; onClick: () => void }) => {
   return (
-    <Link
-      href={`${URL_PATH.GroupList}/${groupId}`}
-      onMouseEnter={onMouseEnter}
+    <button
+      onClick={onClick}
       className={cn('px-6 py-[18px]', 'rounded-md', 'flex gap-6', 'w-[328px]', {
         'bg-white shadow-gray': isActive,
       })}
     >
       <div className='text-title02 text-blue-500'>{rank}</div>
       <div className='flex flex-col gap-3 flex-1'>
-        <p className='text-title02 font-semibold'>{groupName}</p>
+        <p className='text-title02 font-semibold text-left'>{groupName}</p>
         <div className='flex items-center justify-between'>
           <div className='flex gap-x-1'>
-            {categoryNames.map((tag, index) => (
+            {categoryNames.slice(0, 2).map((tag, index) => (
               <Chip
                 key={`group-tag-${index}`}
                 label={tag}
@@ -80,6 +78,6 @@ const PopularGroupCard = ({
           </div>
         </div>
       </div>
-    </Link>
+    </button>
   )
 }

--- a/src/app/_components/PopularGroupList.tsx
+++ b/src/app/_components/PopularGroupList.tsx
@@ -23,6 +23,7 @@ const PopularGroupList = () => {
         <div className='flex flex-col gap-y-2'>
           {popularGroupList.slice(0, 3).map((props, index) => (
             <PopularGroupCard
+              rank={index + 1}
               isActive={currentActiveRetrospect === index}
               onMouseEnter={() => {
                 setCurrentActiveRetrospect(index)
@@ -43,43 +44,42 @@ const PopularGroupList = () => {
 export default PopularGroupList
 
 const PopularGroupCard = ({
+  rank,
   isActive,
   onMouseEnter,
   groupId,
   groupName,
   userCount,
   categoryNames,
-}: Group & { isActive: boolean; onMouseEnter: () => void }) => {
+}: Group & { rank: number; isActive: boolean; onMouseEnter: () => void }) => {
   return (
     <Link
       href={`${URL_PATH.GroupList}/${groupId}`}
       onMouseEnter={onMouseEnter}
-      className={cn(
-        'px-6 py-[18px]',
-        'bg-white',
-        'rounded-md',
-        'w-[328px]',
-        'shadow-gray',
-        'hover:bg-[#FEFCF9]',
-      )}
+      className={cn('px-6 py-[18px]', 'rounded-md', 'flex gap-6', 'w-[328px]', {
+        'bg-white shadow-gray': isActive,
+      })}
     >
-      <div className='flex gap-x-1 mb-1'>
-        {categoryNames.map((tag, index) => (
-          <Chip
-            key={`group-tag-${index}`}
-            label={tag}
-            color='gray'
-            size='small'
-          />
-        ))}
-      </div>
-      <p className='text-title02 font-semibold'>{groupName}</p>
-      {isActive && (
-        <div className='text-gray-400 text-body02 mt-2 flex items-center gap-x-1'>
-          <Icon name='profile-filled' className='fill-gray-400' size={18} />
-          멤버 {userCount}명
+      <div className='text-title02 text-blue-500'>{rank}</div>
+      <div className='flex flex-col gap-3 flex-1'>
+        <p className='text-title02 font-semibold'>{groupName}</p>
+        <div className='flex items-center justify-between'>
+          <div className='flex gap-x-1'>
+            {categoryNames.map((tag, index) => (
+              <Chip
+                key={`group-tag-${index}`}
+                label={tag}
+                color={isActive ? 'lightBlue' : 'linear'}
+                size='small'
+              />
+            ))}
+          </div>
+          <div className='text-gray-400 text-body02 flex items-center gap-x-1'>
+            <Icon name='profile-filled' className='fill-gray-400' size={18} />
+            멤버 {userCount}명
+          </div>
         </div>
-      )}
+      </div>
     </Link>
   )
 }

--- a/src/app/_components/PopularRetrospectCard.tsx
+++ b/src/app/_components/PopularRetrospectCard.tsx
@@ -2,22 +2,25 @@ import { Retrospect } from '@/app/_types'
 import AuthorInfo from '@/components/AuthorInfo'
 import Link from 'next/link'
 import { URL_PATH } from '@/consts/urls'
+import { Icon } from '@/components/Icon'
 
 const PopularRetrospectCard = ({
-  retrospectId,
+  groupId,
   title,
   content,
   userName,
   timeString,
-}: Retrospect) => {
+}: { groupId: number } & Retrospect) => {
   return (
-    <div className='bg-white rounded-md p-6 relative w-full'>
-      <h4 className='text-title01 mb-2'>{title}</h4>
-      <AuthorInfo
-        size='medium'
-        author={userName}
-        latestUpdateTime={timeString}
-      />
+    <div className='bg-white rounded-md p-6 w-full flex flex-col'>
+      <div className='flex items-center justify-between'>
+        <h4 className='text-title01 mb-2'>{title}</h4>
+        <AuthorInfo
+          size='medium'
+          author={userName}
+          latestUpdateTime={timeString}
+        />
+      </div>
       <div
         className='text-gray-700 text-body02 font-normal mt-6 whitespace-pre-wrap line-clamp-5'
         dangerouslySetInnerHTML={{
@@ -25,10 +28,11 @@ const PopularRetrospectCard = ({
         }}
       />
       <Link
-        href={`${URL_PATH.Retrospects}/${retrospectId}`}
-        className=' bottom-6 text-blue-500 text-body02 mt-4 block'
+        href={`${URL_PATH.GroupList}/${groupId}`}
+        className='flex text-blue-500 text-body02 mt-auto ml-auto'
       >
-        더보기
+        모임구경하기
+        <Icon name='arrow-right' size={23} />
       </Link>
     </div>
   )

--- a/src/assets/icons/arrow-left.svg
+++ b/src/assets/icons/arrow-left.svg
@@ -1,3 +1,3 @@
-<svg width="28" height="29" viewBox="0 0 28 29" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="current" height="current" viewBox="0 0 28 29" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M16.9998 22.4201L10.4798 15.9001C9.70984 15.1301 9.70984 13.8701 10.4798 13.1001L16.9998 6.58008" stroke="#737373" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/assets/icons/arrow-right.svg
+++ b/src/assets/icons/arrow-right.svg
@@ -1,3 +1,3 @@
-<svg width="28" height="29" viewBox="0 0 28 29" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="current" height="current" viewBox="0 0 28 29" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M10.9102 22.4201L17.4302 15.9001C18.2002 15.1301 18.2002 13.8701 17.4302 13.1001L10.9102 6.58008" stroke="#737373" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/components/Chip/index.tsx
+++ b/src/components/Chip/index.tsx
@@ -2,16 +2,29 @@ import { cn } from '@/utils/cn'
 
 interface Props {
   label: string
-  color: 'gray' | 'blue' | 'black' | 'green' | 'orange'
+  color:
+    | 'gray'
+    | 'blue'
+    | 'black'
+    | 'green'
+    | 'orange'
+    | 'lightBlue'
+    | 'lightGreen'
+    | 'lightOrange'
+    | 'linear'
   size: 'small' | 'medium'
 }
 
 const CHIP_COLOR: Record<Props['color'], string> = {
-  gray: 'bg-gray-50 text-gray-800',
+  gray: 'bg-gray-50',
   blue: 'bg-blue-500 text-white',
   black: 'bg-gray-800 text-white',
   green: 'bg-green-500 text-white',
   orange: 'bg-orange-500 text-white',
+  lightBlue: 'bg-blue-50',
+  lightGreen: 'bg-green-50',
+  lightOrange: 'bg-orange-50',
+  linear: 'bg-gray-50 border border-gray-100',
 }
 
 const Chip = ({ size, color, label }: Props) => {
@@ -25,6 +38,7 @@ const Chip = ({ size, color, label }: Props) => {
         'rounded-sm',
         'px-3',
         'text-nowrap',
+        'text-gray-800',
         {
           'h-7': size === 'small',
         },


### PR DESCRIPTION
## #️⃣연관된 이슈

- #89 

## 📝작업 내용

 
- Chip 컴포넌트 개선 d0f39b248357376d0303ebc03217ac564eed3ca2
  - 색상 옵션 확장
- 홈 화면 인기 모임 UI 수정
	- 기존: 그룹카드(모임)에 마우스를 올리면(onMouseEnter) UI 활성화
	- 변경: 클릭 시(onClick) 모임이 활성화(isActive)되는 방식으로 이벤트 로직 변경
	- 회고글로 이동하던 Navigate를 모임 상세 페이지 이동으로 수정


### 스크린샷 (선택)
<img width="814" height="352" alt="image" src="https://github.com/user-attachments/assets/c8e331de-2bab-4dc2-9267-8a4b425d6b81" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
