### PR TITLE
feat: AuthGuard 컴포넌트를 추가하여 라우트를 보호하고 사용자 인증 확인

### DIFF
--- a/src/app/AuthGuard.tsx
+++ b/src/app/AuthGuard.tsx
@@ -1,0 +1,29 @@
+// components/AuthGuard.tsx
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import { getAccessToken } from '@/utils/auth'
+
+interface Props {
+  children: React.ReactNode
+}
+
+export default function AuthGuard({ children }: Props) {
+  const router = useRouter()
+  const [checked, setChecked] = useState(false) // localStorage 확인 완료 여부
+
+  useEffect(() => {
+    const token = getAccessToken()
+
+    if (!token) {
+      router.replace('/login') // 로그인 안 되어 있으면 로그인 페이지로 이동
+    } else {
+      setChecked(true) // 토큰이 있다면 렌더링 허용
+    }
+  }, [])
+
+  if (!checked) return null // 확인 전에는 아무 것도 렌더링하지 않음
+
+  return <>{children}</>
+}

--- a/src/app/groups/(form)/create/page.tsx
+++ b/src/app/groups/(form)/create/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next'
 import GroupForm from '../GroupForm'
+import AuthGuard from '@/app/AuthGuard'
 
 export const metadata: Metadata = {
   title: 'Leev | 모임 생성',
@@ -10,10 +11,12 @@ export const metadata: Metadata = {
  */
 const GroupCreatePage = () => {
   return (
-    <div className='px-[88px] pt-[72px] pb-[66px]'>
-      <h1 className='text-display01 mb-6'>회고 모임 만들기</h1>
-      <GroupForm mode='create' />
-    </div>
+    <AuthGuard>
+      <div className='px-[88px] pt-[72px] pb-[66px]'>
+        <h1 className='text-display01 mb-6'>회고 모임 만들기</h1>
+        <GroupForm mode='create' />
+      </div>
+    </AuthGuard>
   )
 }
 

--- a/src/app/groups/(form)/update/[id]/page.tsx
+++ b/src/app/groups/(form)/update/[id]/page.tsx
@@ -1,11 +1,14 @@
 import GroupForm from '@/app/groups/(form)/GroupForm'
+import AuthGuard from '@/app/AuthGuard'
 
 const UpdateGroupPage = () => {
   return (
-    <div className='px-[88px] pt-[72px] pb-[66px]'>
-      <h1 className='text-display01 mb-6'>모임 정보 수정</h1>
-      <GroupForm mode='update' />
-    </div>
+    <AuthGuard>
+      <div className='px-[88px] pt-[72px] pb-[66px]'>
+        <h1 className='text-display01 mb-6'>모임 정보 수정</h1>
+        <GroupForm mode='update' />
+      </div>
+    </AuthGuard>
   )
 }
 

--- a/src/app/groups/[id]/page.tsx
+++ b/src/app/groups/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next'
 import GroupDetail from './GroupDetail'
+import AuthGuard from '@/app/AuthGuard'
 /**
  * 모임 상세 페이지
  */
@@ -10,7 +11,11 @@ export const metadata: Metadata = {
 }
 
 const GroupDetailPage = () => {
-  return <GroupDetail />
+  return (
+    <AuthGuard>
+      <GroupDetail />
+    </AuthGuard>
+  )
 }
 
 export default GroupDetailPage

--- a/src/app/groups/page.tsx
+++ b/src/app/groups/page.tsx
@@ -2,13 +2,16 @@
 
 import MyGroupList from './_components/MyGroupList'
 import GroupSearch from '@/app/groups/_components/GroupSearch'
+import AuthGuard from '@/app/AuthGuard'
 
 const GroupsPage = () => {
   return (
-    <div className='flex flex-col gap-14 px-[88px] py-[72px]'>
-      <MyGroupList />
-      <GroupSearch />
-    </div>
+    <AuthGuard>
+      <div className='flex flex-col gap-14 px-[88px] py-[72px]'>
+        <MyGroupList />
+        <GroupSearch />
+      </div>
+    </AuthGuard>
   )
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next'
 import HomeContainer from './HomeContainer'
+import AuthGuard from '@/app/AuthGuard'
 
 // TODO: 추후 변경 필요
 export const metadata: Metadata = {
@@ -7,5 +8,9 @@ export const metadata: Metadata = {
 }
 
 export default function Home() {
-  return <HomeContainer />
+  return (
+    <AuthGuard>
+      <HomeContainer />
+    </AuthGuard>
+  )
 }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -3,6 +3,7 @@
 import useUserDataQuery from '@/queries/useUserDataQuery'
 import MyRetrospectStatus from '@/app/retrospects/_components/MyRetrospectStatus'
 import ChipButton from '@/components/ChipButton'
+import AuthGuard from '@/app/AuthGuard'
 
 const ProfilePage = () => {
   const { userData } = useUserDataQuery()
@@ -10,22 +11,24 @@ const ProfilePage = () => {
   if (!userData) return null
 
   return (
-    <div className='px-[88px] py-[70px]'>
-      <div className='p-10 mb-20 bg-gray-50 rounded-md'>
-        <p className='text-title01'>{userData.nickname}님 안녕하세요!</p>
-        <p className='mt-4 text-body03 text-gray-500'>관심있는 키워드</p>
-        <div className='mt-2 flex text-body03 gap-2'>
-          {userData.featureKeywordList.map((keyword, index) => (
-            <ChipButton
-              key={`${keyword}-${index}`}
-              label={keyword}
-              disabled={true}
-            />
-          ))}
+    <AuthGuard>
+      <div className='px-[88px] py-[70px]'>
+        <div className='p-10 mb-20 bg-gray-50 rounded-md'>
+          <p className='text-title01'>{userData.nickname}님 안녕하세요!</p>
+          <p className='mt-4 text-body03 text-gray-500'>관심있는 키워드</p>
+          <div className='mt-2 flex text-body03 gap-2'>
+            {userData.featureKeywordList.map((keyword, index) => (
+              <ChipButton
+                key={`${keyword}-${index}`}
+                label={keyword}
+                disabled={true}
+              />
+            ))}
+          </div>
         </div>
+        <MyRetrospectStatus />
       </div>
-      <MyRetrospectStatus />
-    </div>
+    </AuthGuard>
   )
 }
 

--- a/src/app/retrospects/[id]/page.tsx
+++ b/src/app/retrospects/[id]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import Retrospect from './Retrospect'
+import AuthGuard from '@/app/AuthGuard'
 
 // TODO: 추후 회고록 제목 포함으로 변경 필요
 export const metadata: Metadata = {
@@ -7,6 +8,10 @@ export const metadata: Metadata = {
 }
 
 const RetrospectPage = () => {
-  return <Retrospect />
+  return (
+    <AuthGuard>
+      <Retrospect />
+    </AuthGuard>
+  )
 }
 export default RetrospectPage

--- a/src/app/retrospects/create/[[...memoId]]/page.tsx
+++ b/src/app/retrospects/create/[[...memoId]]/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next'
 import RetrospectCreate from './RetrospectCreate'
+import AuthGuard from '@/app/AuthGuard'
 
 export const metadata: Metadata = {
   title: 'Leev | 회고 작성',
@@ -12,6 +13,10 @@ const RetrospectCreatePage = async ({
 }) => {
   const { memoId } = await params
 
-  return <RetrospectCreate memoId={Number(memoId?.[0]) || null} />
+  return (
+    <AuthGuard>
+      <RetrospectCreate memoId={Number(memoId?.[0]) || null} />
+    </AuthGuard>
+  )
 }
 export default RetrospectCreatePage

--- a/src/app/retrospects/my/page.tsx
+++ b/src/app/retrospects/my/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import RetrospectCard from '../_components/RetrospectCard'
 import useUserDataQuery from '@/queries/useUserDataQuery'
 import useMyRetrospectListQuery from '../_queries/useMyRetrospectListQuery'
+import AuthGuard from '@/app/AuthGuard'
 
 const MyRetrospectsPage = () => {
   const { back } = useRouter()
@@ -13,7 +14,7 @@ const MyRetrospectsPage = () => {
   if (!userData) return null
 
   return (
-    <>
+    <AuthGuard>
       <button
         className='flex items-center my-3 mx-4 text-body03 text-gray-900'
         onClick={() => {
@@ -43,7 +44,7 @@ const MyRetrospectsPage = () => {
           ))}
         </div>
       </div>
-    </>
+    </AuthGuard>
   )
 }
 export default MyRetrospectsPage

--- a/src/app/retrospects/page.tsx
+++ b/src/app/retrospects/page.tsx
@@ -1,13 +1,16 @@
 import TemplateList from '@/app/_components/TemplateList'
 import MyRetrospectStatus from './_components/MyRetrospectStatus'
+import AuthGuard from '@/app/AuthGuard'
 
 const RetrospectsPage = () => {
   return (
-    <div className='flex flex-col gap-[50px] py-[70px] px-[88px]'>
-      <h1 className='text-display01'>회고스페이스</h1>
-      <TemplateList />
-      <MyRetrospectStatus />
-    </div>
+    <AuthGuard>
+      <div className='flex flex-col gap-[50px] py-[70px] px-[88px]'>
+        <h1 className='text-display01'>회고스페이스</h1>
+        <TemplateList />
+        <MyRetrospectStatus />
+      </div>
+    </AuthGuard>
   )
 }
 

--- a/src/app/retrospects/template/[id]/page.tsx
+++ b/src/app/retrospects/template/[id]/page.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/navigation'
 import useGetTemplate from '@/app/_queries/useGetTemplate'
 import { usePathname } from 'next/navigation'
 import DOMPurify from 'isomorphic-dompurify'
+import AuthGuard from '@/app/AuthGuard'
 
 const TemplatePage = () => {
   const { back } = useRouter()
@@ -18,7 +19,7 @@ const TemplatePage = () => {
   if (!template) return null
 
   return (
-    <>
+    <AuthGuard>
       <button
         className='flex items-center my-3 mx-4 text-body03 text-gray-900'
         onClick={() => {
@@ -50,7 +51,7 @@ const TemplatePage = () => {
           }}
         />
       </div>
-    </>
+    </AuthGuard>
   )
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #50 

## 📝작업 내용

AuthGuard 컴포넌트를 추가하여 라우트를 보호하고 사용자 인증을 확인하도록 구현했습니다.

- 현재 accessToken을 localStorage로 관리하고 있기 때문에, Next.js의 middleware를 통한 인증 처리는 사용할 수 없어 AuthGuard 컴포넌트로 대체했습니다.

- 추후 인증 방식을 쿠키 기반으로 변경할 계획이며, 그에 따라 middleware를 활용한 방식으로 전환할 예정입니다.



### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
