### PR TITLE
Feat/#96 SanitizedHtmlRenderer 공통 컴포넌트로 분리 및 내부 태그들 스타일 추가

### DIFF
--- a/src/app/_components/PopularRetrospectCard.tsx
+++ b/src/app/_components/PopularRetrospectCard.tsx
@@ -3,6 +3,7 @@ import AuthorInfo from '@/components/AuthorInfo'
 import Link from 'next/link'
 import { URL_PATH } from '@/consts/urls'
 import { Icon } from '@/components/Icon'
+import SanitizedHtmlRenderer from '@/components/SanitizedHtmlRenderer'
 
 const PopularRetrospectCard = ({
   groupId,
@@ -21,11 +22,9 @@ const PopularRetrospectCard = ({
           latestUpdateTime={timeString}
         />
       </div>
-      <div
+      <SanitizedHtmlRenderer
+        content={content}
         className='text-gray-700 text-body02 font-normal mt-6 whitespace-pre-wrap line-clamp-5'
-        dangerouslySetInnerHTML={{
-          __html: content,
-        }}
       />
       <Link
         href={`${URL_PATH.GroupList}/${groupId}`}

--- a/src/app/_components/TemplateList.tsx
+++ b/src/app/_components/TemplateList.tsx
@@ -5,11 +5,11 @@ import Chip from '@/components/Chip'
 import SectionHeader from './SectionHeader'
 
 import { Template } from '../_types/template'
-import DOMPurify from 'isomorphic-dompurify'
 
 import useGetTemplateList from '@/app/_queries/useGetTemplateList'
 import SliderContainer from '@/app/_components/SliderContainer'
 import { URL_PATH } from '@/consts/urls'
+import SanitizedHtmlRenderer from '@/components/SanitizedHtmlRenderer'
 
 /** 템플릿 영역 */
 const TemplateList = () => {
@@ -47,11 +47,9 @@ const TemplateCard = ({
       <div className='flex flex-col justify-between overflow-hidden'>
         <div>
           <h4 className='text-body01 font-semibold mb-2'>{templateName}</h4>
-          <div
+          <SanitizedHtmlRenderer
+            content={content}
             className='text-gray-700 text-body03 font-normal line-clamp-3 whitespace-pre-wrap'
-            dangerouslySetInnerHTML={{
-              __html: DOMPurify.sanitize(content),
-            }}
           />
         </div>
         <div className='flex gap-1 text-body03 overflow-auto pb-1'>

--- a/src/app/groups/[id]/_components/RetrospectList.tsx
+++ b/src/app/groups/[id]/_components/RetrospectList.tsx
@@ -9,8 +9,8 @@ import IconWithButton from '@/app/retrospects/[id]/_components/IconWithButton'
 import type { RetrospectList } from '../_types'
 import { URL_PATH } from '@/consts/urls'
 import { useRouter } from 'next/navigation'
-import DOMPurify from 'isomorphic-dompurify'
 import OpenMemoListModalButton from '@/app/_components/OpenMemoListModalButton'
+import SanitizedHtmlRenderer from '@/components/SanitizedHtmlRenderer'
 
 const RetrospectList = ({
   retrospectList,
@@ -78,9 +78,9 @@ export const RetrospectListItem = ({
           author={userName}
           latestUpdateTime={timeString}
         />
-        <div
+        <SanitizedHtmlRenderer
+          content={content}
           className='mt-10 text-body02 text-gray-700 whitespace-pre-wrap'
-          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(content) }}
         />
         <Link
           href={`${URL_PATH.Retrospects}/${retrospectId}`}

--- a/src/app/retrospects/[id]/Retrospect.tsx
+++ b/src/app/retrospects/[id]/Retrospect.tsx
@@ -9,12 +9,11 @@ import RetrospectHeading from './_components/RetrospectHeading'
 import { useParams } from 'next/navigation'
 import useGetRetrospect from '@/app/groups/[id]/_queries/useGetRetrospect'
 import useGetCommentList from '@/app/groups/[id]/_queries/useGetCommentList'
-import DOMPurify from 'isomorphic-dompurify'
 import IconWithButton from './_components/IconWithButton'
 import RetrospectActionDropDown from './_components/RetrospectActionDropDown'
 import Confirm from '@/components/Confirm'
 import useDeleteRetrospectMutation from './_queries/useDeleteRetrospectMutation'
-import './_styles/index.css'
+import SanitizedHtmlRenderer from '@/components/SanitizedHtmlRenderer'
 
 const Retrospect = () => {
   const retrospectId = useParams<{ id: string }>()?.id
@@ -65,11 +64,9 @@ const Retrospect = () => {
           author={userName}
           latestUpdateTime={timeString}
         />
-        <main
-          id='article-content'
-          className='mt-16 whitespace-pre-wrap'
-          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(content) }}
-        />
+        <main className='mt-16 whitespace-pre-wrap'>
+          <SanitizedHtmlRenderer content={content} />
+        </main>
         <div className='mt-[72px] flex gap-6'>
           {/*<IconWithButton iconName='like' count={likeCount} />*/}
           <IconWithButton

--- a/src/app/retrospects/_components/RetrospectCard.tsx
+++ b/src/app/retrospects/_components/RetrospectCard.tsx
@@ -2,7 +2,7 @@ import CardWrap from '@/components/CardWrap'
 import { URL_PATH } from '@/consts/urls'
 // import Chip from '@/components/Chip'
 import { Retrospect } from '@/app/_types'
-import DOMPurify from 'isomorphic-dompurify'
+import SanitizedHtmlRenderer from '@/components/SanitizedHtmlRenderer'
 
 const RetrospectCard = ({
   retrospectId,
@@ -28,11 +28,9 @@ const RetrospectCard = ({
         {/*  ))}*/}
         {/*</div>*/}
         <h4 className='text-body01 font-semibold mb-2'>{title}</h4>
-        <div
+        <SanitizedHtmlRenderer
+          content={content}
           className='text-body03 font-normal text-gray-600 line-clamp-3'
-          dangerouslySetInnerHTML={{
-            __html: DOMPurify.sanitize(content),
-          }}
         />
       </div>
     </CardWrap>

--- a/src/app/retrospects/create/[[...memoId]]/_components/TemplateModal.tsx
+++ b/src/app/retrospects/create/[[...memoId]]/_components/TemplateModal.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '@/components/Icon'
 import Modal from '@/components/Modal'
 import { Template } from '@/app/_types/template'
-import DOMPurify from 'isomorphic-dompurify'
+import SanitizedHtmlRenderer from '@/components/SanitizedHtmlRenderer'
 
 interface Props {
   isOpen: boolean
@@ -27,11 +27,9 @@ const TemplateModal = ({
             <Icon name='close' size={24} />
           </button>
         </div>
-        <div
+        <SanitizedHtmlRenderer
+          content={content}
           className='bg-gray-50 rounded-sm p-5 whitespace-pre-wrap'
-          dangerouslySetInnerHTML={{
-            __html: DOMPurify.sanitize(content),
-          }}
         />
       </div>
     </Modal>

--- a/src/app/retrospects/template/[id]/page.tsx
+++ b/src/app/retrospects/template/[id]/page.tsx
@@ -7,8 +7,8 @@ import { URL_PATH } from '@/consts/urls'
 import { useRouter } from 'next/navigation'
 import useGetTemplate from '@/app/_queries/useGetTemplate'
 import { usePathname } from 'next/navigation'
-import DOMPurify from 'isomorphic-dompurify'
 import AuthGuard from '@/app/AuthGuard'
+import SanitizedHtmlRenderer from '@/components/SanitizedHtmlRenderer'
 
 const TemplatePage = () => {
   const { back } = useRouter()
@@ -44,11 +44,9 @@ const TemplatePage = () => {
             </Button>
           </Link>
         </div>
-        <div
+        <SanitizedHtmlRenderer
+          content={template.content}
           className='bg-gray-50 rounded-sm p-10 whitespace-pre-wrap'
-          dangerouslySetInnerHTML={{
-            __html: DOMPurify.sanitize(template.content),
-          }}
         />
       </div>
     </AuthGuard>

--- a/src/components/SanitizedHtmlRenderer/index.css
+++ b/src/components/SanitizedHtmlRenderer/index.css
@@ -8,6 +8,7 @@
         margin-right: 0;
         font-weight: bold;
     }
+
     h2 {
         display: block;
         font-size: 1.5em;

--- a/src/components/SanitizedHtmlRenderer/index.tsx
+++ b/src/components/SanitizedHtmlRenderer/index.tsx
@@ -1,0 +1,22 @@
+import DOMPurify from 'isomorphic-dompurify'
+import './index.css'
+
+const SanitizedHtmlRenderer = ({
+  content,
+  className = '',
+}: {
+  content: string
+  className?: string
+}) => {
+  return (
+    <div
+      className={className}
+      id='article-content'
+      dangerouslySetInnerHTML={{
+        __html: DOMPurify.sanitize(content),
+      }}
+    />
+  )
+}
+
+export default SanitizedHtmlRenderer


### PR DESCRIPTION
## #️⃣연관된 이슈

- #96 

## 📝작업 내용
- dangerouslySetInnerHTML을 사용하는 태그들을 SanitizedHtmlRenderer 공통 컴포넌트로 분리
- index.css에 내부 태그들 (h1, h2, h3, ol, ul, em ...) 스타일 적용

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
