### PR TITLE
feat/#101 로그아웃 기능 추가 및 자잘한 수정

### DIFF
--- a/src/app/_components/PopularRetrospectCard.tsx
+++ b/src/app/_components/PopularRetrospectCard.tsx
@@ -13,7 +13,7 @@ const PopularRetrospectCard = ({
   timeString,
 }: { groupId: number } & Retrospect) => {
   return (
-    <div className='bg-white rounded-md p-6 w-full flex flex-col'>
+    <div className='bg-white rounded-md p-6 w-full h-[344px] flex flex-col'>
       <div className='flex items-center justify-between'>
         <h4 className='text-title01 mb-2'>{title}</h4>
         <AuthorInfo
@@ -24,7 +24,7 @@ const PopularRetrospectCard = ({
       </div>
       <SanitizedHtmlRenderer
         content={content}
-        className='text-gray-700 text-body02 font-normal mt-6 whitespace-pre-wrap line-clamp-5'
+        className='text-gray-700 text-body02 font-normal mt-6 line-clamp-5'
       />
       <Link
         href={`${URL_PATH.GroupList}/${groupId}`}

--- a/src/app/_components/TemplateList.tsx
+++ b/src/app/_components/TemplateList.tsx
@@ -44,16 +44,14 @@ const TemplateCard = ({
       height={182}
       size='medium'
     >
-      <div className='flex flex-col justify-between overflow-hidden'>
-        <div>
-          <h4 className='text-body01 font-semibold mb-2'>{templateName}</h4>
-          <SanitizedHtmlRenderer
-            content={content}
-            className='text-gray-700 text-body03 font-normal line-clamp-3 whitespace-pre-wrap'
-          />
-        </div>
-        <div className='flex gap-1 text-body03 overflow-auto pb-1'>
-          {categories.map((tag, index) => (
+      <div className='flex flex-col justify-between overflow-hidden gap-2'>
+        <h4 className='text-body01 font-semibold'>{templateName}</h4>
+        <SanitizedHtmlRenderer
+          content={content}
+          className='text-gray-700 text-body03 font-normal line-clamp-3'
+        />
+        <div className='flex gap-x-1 text-body03'>
+          {categories.slice(0, 4).map((tag, index) => (
             <Chip key={`tag-${index}`} size='small' color='gray' label={tag} />
           ))}
         </div>

--- a/src/app/groups/[id]/GroupDetail.tsx
+++ b/src/app/groups/[id]/GroupDetail.tsx
@@ -7,7 +7,6 @@ import GroupInfoList from './_components/GroupInfoList'
 import NoRetrospectList from './_components/NoRetrospectList'
 import RetrospectList from './_components/RetrospectList'
 import { useParams } from 'next/navigation'
-import Spinner from '@/components/Spinner'
 import useGetGroupInfo from './_queries/useGetGroupInfo'
 import useGetRetrospectList from './_queries/useGetRetrospectList'
 import { ROLE } from './_consts'
@@ -28,7 +27,7 @@ const GroupDetail = () => {
   const { mutate: deleteGroup } = useDeleteGroupMutation(String(groupId))
   const { mutate: leaveGroup } = useLeaveGroupMutation(String(groupId))
 
-  if (!groupInfo) return <Spinner />
+  if (!groupInfo) return null
 
   const confirmModalContent: ConfirmModal =
     groupInfo.role === 'LEADER'

--- a/src/app/groups/[id]/_components/RetrospectList.tsx
+++ b/src/app/groups/[id]/_components/RetrospectList.tsx
@@ -80,7 +80,7 @@ export const RetrospectListItem = ({
         />
         <SanitizedHtmlRenderer
           content={content}
-          className='mt-10 text-body02 text-gray-700 whitespace-pre-wrap'
+          className='mt-10 text-body02 text-gray-700'
         />
         <Link
           href={`${URL_PATH.Retrospects}/${retrospectId}`}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,11 @@
+import { Spinner } from '@heroui/spinner'
+
+const Loading = () => {
+  return (
+    <div className='w-full h-full flex flex-col items-center justify-center'>
+      <Spinner size='lg' />
+    </div>
+  )
+}
+
+export default Loading

--- a/src/app/retrospects/[id]/Retrospect.tsx
+++ b/src/app/retrospects/[id]/Retrospect.tsx
@@ -64,7 +64,7 @@ const Retrospect = () => {
           author={userName}
           latestUpdateTime={timeString}
         />
-        <main className='mt-16 whitespace-pre-wrap'>
+        <main className='mt-16'>
           <SanitizedHtmlRenderer content={content} />
         </main>
         <div className='mt-[72px] flex gap-6'>

--- a/src/app/retrospects/_components/RetrospectCard.tsx
+++ b/src/app/retrospects/_components/RetrospectCard.tsx
@@ -15,7 +15,7 @@ const RetrospectCard = ({
       size='medium'
       height={182}
     >
-      <div>
+      <div className='overflow-hidden'>
         {/*태그 기능  후순위*/}
         {/*<div className='flex gap-x-1 mb-2 text-body03'>*/}
         {/*  {categoryNames.map((tag, index) => (*/}
@@ -30,7 +30,8 @@ const RetrospectCard = ({
         <h4 className='text-body01 font-semibold mb-2'>{title}</h4>
         <SanitizedHtmlRenderer
           content={content}
-          className='text-body03 font-normal text-gray-600 line-clamp-3'
+          className='text-body03 font-normal text-gray-600 line-clamp-4'
+          useStyle={false}
         />
       </div>
     </CardWrap>

--- a/src/app/retrospects/_components/RetrospectCard.tsx
+++ b/src/app/retrospects/_components/RetrospectCard.tsx
@@ -27,7 +27,7 @@ const RetrospectCard = ({
         {/*    />*/}
         {/*  ))}*/}
         {/*</div>*/}
-        <h4 className='text-body01 font-semibold mb-2'>{title}</h4>
+        <h4 className='text-body01 font-semibold mb-2 line-clamp-1'>{title}</h4>
         <SanitizedHtmlRenderer
           content={content}
           className='text-body03 font-normal text-gray-600 line-clamp-4'

--- a/src/app/retrospects/create/[[...id]]/_components/Editor.tsx
+++ b/src/app/retrospects/create/[[...id]]/_components/Editor.tsx
@@ -70,7 +70,7 @@ const Editor = ({
           title={title}
           groupId={Number(retrospectInfo.groupId)}
           templateId={retrospectInfo.templateId ?? 0}
-          initMemoId={isRetrospectUpdate ? null : id}
+          id={id}
           isRetrospectUpdate={isRetrospectUpdate}
         />
         <div className='bg-white py-6 px-10 rounded-md'>

--- a/src/app/retrospects/create/[[...id]]/_components/SubmitHeader/RetrospectSubmitButton.tsx
+++ b/src/app/retrospects/create/[[...id]]/_components/SubmitHeader/RetrospectSubmitButton.tsx
@@ -54,6 +54,7 @@ const RetrospectSubmitButton = ({
     const retrospectUpdateOnSuccess = async (data: MutationResponseUnion) => {
       if ('retrospectId' in data) {
         await invalidateQueries(['getRetrospect', String(data.retrospectId)])
+        await invalidateQueries(['MyRetrospect'])
         replace(`${URL_PATH.Retrospects}/${data.retrospectId}`)
       }
     }

--- a/src/app/retrospects/create/[[...id]]/_components/SubmitHeader/SubmitHeader.tsx
+++ b/src/app/retrospects/create/[[...id]]/_components/SubmitHeader/SubmitHeader.tsx
@@ -15,7 +15,7 @@ interface Props {
   title: RetrospectCreateForm['title']
   groupId: RetrospectCreateForm['groupId']
   templateId: MemoCreateForm['templateId']
-  initMemoId: number | null
+  id: number | null
   isRetrospectUpdate: boolean
 }
 
@@ -23,10 +23,11 @@ const SubmitHeader = ({
   title,
   groupId,
   templateId,
-  initMemoId,
+  id,
   isRetrospectUpdate,
 }: Props) => {
   const [editor] = useLexicalComposerContext()
+  const initMemoId = isRetrospectUpdate ? null : id
   const memoId = useRef(initMemoId)
   const { back } = useRouter()
   const hasTitle = !(title.trim().length > 0)
@@ -58,7 +59,7 @@ const SubmitHeader = ({
           hasTitle={hasTitle}
         />
         <RetrospectSubmitButton
-          retrospectId={memoId.current}
+          retrospectId={id}
           templateId={templateId}
           basePayload={basePayload}
           hasTitle={hasTitle}

--- a/src/app/retrospects/create/[[...id]]/_components/TemplateModal.tsx
+++ b/src/app/retrospects/create/[[...id]]/_components/TemplateModal.tsx
@@ -29,7 +29,7 @@ const TemplateModal = ({
         </div>
         <SanitizedHtmlRenderer
           content={content}
-          className='bg-gray-50 rounded-sm p-5 whitespace-pre-wrap'
+          className='bg-gray-50 rounded-sm p-5'
         />
       </div>
     </Modal>

--- a/src/app/retrospects/template/[id]/page.tsx
+++ b/src/app/retrospects/template/[id]/page.tsx
@@ -46,7 +46,7 @@ const TemplatePage = () => {
         </div>
         <SanitizedHtmlRenderer
           content={template.content}
-          className='bg-gray-50 rounded-sm p-10 whitespace-pre-wrap'
+          className='bg-gray-50 rounded-sm p-10'
         />
       </div>
     </AuthGuard>

--- a/src/components/RootLayout/SidebarItem/LogoutButton.tsx
+++ b/src/components/RootLayout/SidebarItem/LogoutButton.tsx
@@ -1,9 +1,17 @@
 import { cn } from '@/utils/cn'
 import { Icon } from '@/components/Icon'
+import { removeLocalStorage } from '@/utils/storage'
+import { ACCESS_TOKEN_STORAGE_KEY } from '@/utils/auth'
 
 const LogoutButton = () => {
   return (
-    <button className={cn('flex gap-2', 'mt-auto', 'text-title03')}>
+    <button
+      className={cn('flex gap-2', 'mt-auto', 'text-title03')}
+      onClick={() => {
+        removeLocalStorage(ACCESS_TOKEN_STORAGE_KEY)
+        window.location.reload()
+      }}
+    >
       <Icon name='logout' className='stroke-white' />
       <span className='text-white'>로그아웃</span>
     </button>

--- a/src/components/SanitizedHtmlRenderer/index.tsx
+++ b/src/components/SanitizedHtmlRenderer/index.tsx
@@ -4,14 +4,16 @@ import './index.css'
 const SanitizedHtmlRenderer = ({
   content,
   className = '',
+  useStyle = true,
 }: {
   content: string
   className?: string
+  useStyle?: boolean
 }) => {
   return (
     <div
-      className={className}
-      id='article-content'
+      className={className + ' whitespace-pre-wrap break-words'}
+      id={useStyle ? 'article-content' : ''}
       dangerouslySetInnerHTML={{
         __html: DOMPurify.sanitize(content),
       }}

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,6 +1,6 @@
 import { getLocalStorage, setLocalStorage } from './storage'
 
-const ACCESS_TOKEN_STORAGE_KEY = 'access_token'
+export const ACCESS_TOKEN_STORAGE_KEY = 'access_token'
 const INITIAL_VALUE = ''
 
 export const getAccessToken = () =>

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -36,4 +36,13 @@ export const setLocalStorage = <T>(key: string, newValue: T) => {
   }
 }
 
+export const removeLocalStorage = (key: string) => {
+  if (typeof window === 'undefined') return
+  try {
+    return localStorage.removeItem(key)
+  } catch (error) {
+    console.error('Error remove local storage data', error)
+  }
+}
+
 export const clearLocalStorage = () => localStorage.clear()


### PR DESCRIPTION
## #️⃣연관된 이슈

- #101 

## 📝작업 내용

- 로그아웃 기능 추가 28b1e42
  - `removeLocalStorage` 함수 추가 
- Loading 컴포넌트 생성 2c1ba12
  - 페이지 이동 시 suspense 역할
  - 현재 hero ui의 컴포넌트 사용 중
- `Editor` 및 `SubmitHeader` 컴포넌트에서 일관성을 위해 initMemoId를 id로 변경 c5f1e54
- `SanitizedHtmlRenderer`에 `whitespace-pre-wrap` 와 `break-words` 클래스 적용 d92cc87
- 회고록 수정 성공시 `MyRetrospect` 쿼리키 무효화 추가 62f1bc8
- `RetrospectCard`에서 제목에 `line-clamp-1` 클래스 추가 839905b

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
